### PR TITLE
update-base-image-to-3.13.12-trixie

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract short commit hash
         run: echo "SHORT_HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV

--- a/.github/workflows/docker_build_push.yaml
+++ b/.github/workflows/docker_build_push.yaml
@@ -12,10 +12,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to GHCR and push image
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{github.actor}}

--- a/.github/workflows/docker_build_push_scheduled.yaml
+++ b/.github/workflows/docker_build_push_scheduled.yaml
@@ -11,10 +11,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to GHCR and push image
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{github.actor}}

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13.12-trixie
 
 LABEL maintainer="Blag Ivanov <88674890+echoblag@users.noreply.github.com>"
 


### PR DESCRIPTION
## Description of work done
- Update the base image to `3.13.12-trixie`
- Update the GHA versions to their latest available, address the upcoming Node 20 deprecation.

## Testing notes
Let the CI decide.